### PR TITLE
Add visibility check 

### DIFF
--- a/build_release_notes.py
+++ b/build_release_notes.py
@@ -37,6 +37,7 @@ def combine_data(file_paths, output_file):
 
 
 def is_visible(visibility, show_internal):
+    """"Check whether to render a change artifact in the Jinja template."""
     return visibility == "public" or (visibility == "internal" and show_internal)
 
 def main():

--- a/build_release_notes.py
+++ b/build_release_notes.py
@@ -35,6 +35,10 @@ def combine_data(file_paths, output_file):
 
     save_yaml(combined_data, output_file)
 
+
+def is_visible(visibility, show_internal):
+    return visibility == "public" or (visibility == "internal" and show_internal)
+
 def main():
     """"Generates release notes based on multiple artifacts."""
 
@@ -58,6 +62,7 @@ def main():
 
     # Jinja2 environment 
     env = Environment(loader=FileSystemLoader(template_dir))
+    env.globals['is_visible'] = is_visible
     template = env.get_template(template_file)
 
     # find artifact files

--- a/docs/release-notes/artifacts/pr0004.yaml
+++ b/docs/release-notes/artifacts/pr0004.yaml
@@ -10,4 +10,4 @@ changes:
       related_doc: 
       related_issue: 
     visibility: public
-    highlight: false
+    highlight: true

--- a/docs/release-notes/release-notes-0001.md
+++ b/docs/release-notes/release-notes-0001.md
@@ -1,21 +1,19 @@
-<!-- Remember to update this file for your charm -- replace <charm-name> with the appropriate name,
-follow the release notes policy in the title, and fill in the relevant details. -->
+<!-- Remember to update this file for your charm!! -->
 
 # Fake release notes – latest/stable
 
 These release notes cover new features and changes in Fake for revisions
 1-8 between the dates of 2025-01-01 and 2025-06-01.
 
-<!--
-Add an introduction summarizing the most significant features and impactful changes
-outlined in this file. Organize this content in bulleted lists of "Main features"
-and "Main bug fixes", using past tense to describe each of the items
-(for instance, "Added support for X relation").
--->
-
 Main features:
+
 * Added initial Python script.
 * Added GitHub action.
+
+
+Main breaking changes:
+
+* Renamed feature tag.
 
 
 Main bug fixes:
@@ -35,7 +33,6 @@ below, for instance, a minimum Juju version.
 
 If the user will need any specific upgrade instructions for this
 release, include those instructions here.
-
 -->
 
 The charm operates <workload name with version>.
@@ -51,11 +48,6 @@ The table below shows the required or supported versions of the software necessa
 | XXXX                    | XXXX             |
 
 ## Updates
-
-<!--
-Use this section to highlight major and minor features that were added in this release.
-The subsection below shows the pattern for each feature. Include links to the relevant PR or commit.
--->
 
 The following major and minor features were added in this release.
 
@@ -87,24 +79,8 @@ Relevant links:
 
 
 
-## Bug fixes
-
-<!--
-Add a bulleted list of bug fixes here, with links to the relevant PR/commit.
--->
-
-* Fixed a bug where the URLs weren't rendered correctly in the template ([PR](https://github.com/erinecon/automation-testing-changelog-release-notes/commit/3de734d1f1993d1f56d4f6c6cf9c8f74a6b08ec8)).
-* Fixed feature tag grabbing ([PR](https://github.com/erinecon/automation-testing-changelog-release-notes/commit/50e8f331c1f776483d89d8c7d1e23706e40ba7f4)).
-* Fixed a bug where the automation script incorrectly named the output file ([PR](https://github.com/erinecon/automation-testing-changelog-release-notes/commit/ac0e0db5a810321e64e5b719199b53a0376d08e0)).
-
 
 ## Breaking changes
-
-<!--
-Use this section to highlight any backwards-incompatible changes in this release.
-Include links to the relevant PR or commit.
-If there are no breaking changes, keep the section and write "No breaking changes".
--->
 
 The following backwards-incompatible changes are included in this release.
 
@@ -116,13 +92,15 @@ Relevant links:
 * [PR](https://github.com/erinecon/automation-testing-changelog-release-notes/commit/85abffb0fc3ca2b6a33e62d28be62349f052b041)
 
 
-## Deprecated
+## Bug fixes
 
-<!--
-Use this section to highlight any deprecated features in this release.
-Include links to the relevant PR or commit.
-If there are no deprecated features, keep the section and write "No deprecated features".
--->
+* Fixed a bug where the URLs weren't rendered correctly in the template ([PR](https://github.com/erinecon/automation-testing-changelog-release-notes/commit/3de734d1f1993d1f56d4f6c6cf9c8f74a6b08ec8)).
+* Fixed feature tag grabbing ([PR](https://github.com/erinecon/automation-testing-changelog-release-notes/commit/50e8f331c1f776483d89d8c7d1e23706e40ba7f4)).
+* Fixed a bug where the automation script incorrectly named the output file ([PR](https://github.com/erinecon/automation-testing-changelog-release-notes/commit/ac0e0db5a810321e64e5b719199b53a0376d08e0)).
+
+
+
+## Deprecated
 
 The following features have been deprecated.
 

--- a/docs/release-notes/template/release-template.md.j2
+++ b/docs/release-notes/template/release-template.md.j2
@@ -6,15 +6,24 @@ These release notes cover new features and changes in {{ charm_name }} for revis
 {{ earliest_revision }}-{{ latest_revision }} between the dates of {{ earliest_date }} and {{ latest_date }}.
 
 Main features:
+
 {% for feat in changes -%}
-{%- if feat.highlight == true and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) and (feat.type == "major" or feat.type == "minor") -%}
+{%- if feat.highlight == true and is_visible(feat.visibility, show_internal) and (feat.type in ["major", "minor"]) -%}
+* {{ feat.title }}.
+{% endif -%}
+{% endfor %}
+
+Main breaking changes:
+
+{% for feat in changes -%}
+{%- if feat.highlight == true and is_visible(feat.visibility, show_internal) and (feat.type == "breaking") -%}
 * {{ feat.title }}.
 {% endif -%}
 {% endfor %}
 
 Main bug fixes:
 {% for feat in changes -%}
-{%- if feat.highlight == true and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) and feat.type == "bugfix" -%}
+{%- if feat.highlight == true and is_visible(feat.visibility, show_internal) and feat.type == "bugfix" -%}
 * {{ feat.title }}.
 {% endif -%}
 {% endfor %}
@@ -50,8 +59,7 @@ The table below shows the required or supported versions of the software necessa
 The following major and minor features were added in this release.
 
 {% for feat in changes %}
-{%- if (feat.type == "major" or feat.type == "minor") and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
-
+{%- if (feat.type in ["major", "minor"]) and is_visible(feat.visibility, show_internal) -%}
 ### {{ feat.title }}
 {{ feat.description }}
 <Add more context and information about the entry>
@@ -68,24 +76,20 @@ Relevant links:
 {% endif -%}
 {% endfor %}
 
-## Bug fixes
-
+{% set break = False %}
 {% for feat in changes -%}
-{%- if feat.type == "bugfix" and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
-* {{ feat.title }} ([PR]({{ feat.urls.pr }})).
-{% endif -%}
-{% endfor %}
-
+{% if not break -%}
+{%- if feat.type == "breaking" and is_visible(feat.visibility, show_internal) -%}
 ## Breaking changes
 
-<!--
-If there are no breaking changes in this release, keep the section and write "No breaking changes".
--->
-
 The following backwards-incompatible changes are included in this release.
+{% set break = True %}
+{% endif -%}
+{% endif -%}
+{% endfor -%}
 
 {% for feat in changes -%}
-{%- if feat.type == "breaking" and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
+{%- if feat.type == "breaking" and is_visible(feat.visibility, show_internal) -%}
 ### {{ feat.title }}
 {{ feat.description }}
 <Add more context and information about the entry>
@@ -102,16 +106,28 @@ Relevant links:
 {% endif -%}
 {% endfor %}
 
-## Deprecated
-
-<!--
-If there are no deprecated features in this release, keep the section and write "No deprecated features".
--->
-
-The following features have been deprecated.
+## Bug fixes
 
 {% for feat in changes -%}
-{%- if feat.type == "deprecated" and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
+{%- if feat.type == "bugfix" and is_visible(feat.visibility, show_internal) -%}
+* {{ feat.title }} ([PR]({{ feat.urls.pr }})).
+{% endif -%}
+{% endfor %}
+
+{% set break = False %}
+{% for feat in changes -%}
+{% if not break -%}
+{%- if feat.type == "deprecated" and is_visible(feat.visibility, show_internal) -%}
+## Deprecated
+
+The following features have been deprecated.
+{% set break = True %}
+{% endif -%}
+{% endif -%}
+{% endfor -%}
+
+{% for feat in changes -%}
+{%- if feat.type == "deprecated" and is_visible(feat.visibility, show_internal) -%}
 ### {{ feat.title }}
 {{ feat.description }}
 <Add more context and information about the entry>


### PR DESCRIPTION
### Overview

Updated the Python script and charm release note Jinja template in this repository to include a visibility check. Some other minor changes were also made to the template (added a highlight section for breaking changes, and logic to determine whether "breaking changes" and "deprecated" sections should be rendered at all).

### Rationale 

The Platform Engineering team uses the following visibility-related keys in our artifacts:

* `common.yaml`: the `show_internal` key determines whether to render internal changes
* change artifacts: the `visibility` key determines whether the change is public, internal, or hidden.

The Python script now contains a function, `is_visible`, which is passed to the Jinja template and helps determine whether the change should be rendered.

One example artifact was updated in this repository to verify that this functionality works; see `docs/release-notes/release-notes-0001.md`.