### PR TITLE
Add documentation about action PAT 

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Open pull request
         uses: canonical/create-pull-request@main
         with:
-          github-token: ${{ secrets.RELEASE_NOTES_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Add release notes
           branch-name: add-release-notes
           title: Add release notes

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Open pull request
         uses: canonical/create-pull-request@main
         with:
-          github-token: ${{ secrets.PAT }}
+          github-token: ${{ secrets.RELEASE_NOTES_PAT }}
           commit-message: Add release notes
           branch-name: add-release-notes
           title: Add release notes

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ Delete all previously generated release notes (`***.md` files) from the `release
 
 Create a GitHub workflow, according to the **GitHub workflow** section above.
 
+Add a [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) to your repository called `RELEASE_NOTES_PAT`. The PAT needs to have
+read and write access to code and pull requests.
+
 ### Generating release notes
 
 To generate release notes you need to:

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ Delete all previously generated release notes (`***.md` files) from the `release
 
 Create a GitHub workflow, according to the **GitHub workflow** section above.
 
-Add a [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) to your repository called `RELEASE_NOTES_PAT`. The PAT needs to have
-read and write access to code and pull requests.
+Add a [GitHub token](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token) to your repository called `GITHUB_TOKEN`.
+The token needs to have read and write access to code and pull requests.
 
 ### Generating release notes
 


### PR DESCRIPTION
I realized when testing the process that the documentation in this repo doesn't cover the secrets handling. The user needs to set up a PAT for their repository in order for `create-pull-request` to work properly. 